### PR TITLE
(임시) 토큰 만료 기간을 30일로 수정

### DIFF
--- a/backend/src/main/java/org/mapleleaf/backend/jwt/JwtProvider.java
+++ b/backend/src/main/java/org/mapleleaf/backend/jwt/JwtProvider.java
@@ -27,7 +27,7 @@ public class JwtProvider {
     /* 토큰 생성 메소드 */
     public String createToken(String subject) {
         Date now = new Date();
-        Date expiration = new Date(now.getTime() + Duration.ofHours(2).toMillis()); // 만료기간: 2시간
+        Date expiration = new Date(now.getTime() + Duration.ofDays(30).toMillis()); // 임시만료기간: 30일
 
         return Jwts.builder()
                 .setIssuer("maple-leaf") // 토큰발급자(iss)


### PR DESCRIPTION
#48 Refresh Token 발급 전 임시로 토큰 만료기간을 30일로 수정하였습니다.